### PR TITLE
Fix the URL for ARM64

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -44,6 +44,11 @@ download_release() {
 	if [ "$os" = "darwin" ]; then
 		os="macos"
 	fi
+
+	if [ "$architecture" = "arm64" ]; then
+		architecture="aarch64"
+	fi
+ 
 	url="$GH_REPO/releases/download/${version}/helix-${version}-${architecture}-${os}.tar.xz"
 
 	echo "* Downloading $TOOL_NAME release $version..."


### PR DESCRIPTION
Arm64 architecture in helix releases is referred as aarch64 https://github.com/helix-editor/helix/releases

I had to do this change for my machine (runs on Apple M2)